### PR TITLE
migrate some legacy fields to 2019-09 spec compatible

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -57,7 +57,10 @@ export default class Form extends Component {
     const edit = typeof props.formData !== "undefined";
     const liveValidate = props.liveValidate || this.props.liveValidate;
     const mustValidate = edit && !props.noValidate && liveValidate;
-    const { definitions } = schema;
+
+    // The legacy $defs is used before the 2019-09 release.
+    const definitions = schema.$defs ? schema.$defs : schema.definitions;
+
     const formData = getDefaultFormState(schema, props.formData, definitions);
     const retrievedSchema = retrieveSchema(schema, definitions, formData);
 

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -59,7 +59,7 @@ export default class Form extends Component {
     const mustValidate = edit && !props.noValidate && liveValidate;
 
     // The legacy $defs is used before the 2019-09 release.
-    const definitions = schema.$defs ? schema.$defs : schema.definitions;
+    const definitions = "$defs" in schema ? schema.$defs : schema.definitions;
 
     const formData = getDefaultFormState(schema, props.formData, definitions);
     const retrievedSchema = retrieveSchema(schema, definitions, formData);

--- a/src/utils.js
+++ b/src/utils.js
@@ -386,23 +386,24 @@ export function optionsList(schema) {
 function findSchemaDefinition($ref, definitions = {}) {
   // Extract and use the referenced definition if we have it.
   const match = /^#\/definitions\/(.*)$/.exec($ref);
-  if (match && match[1]) {
-    const parts = match[1].split("/");
-    let current = definitions;
-    for (let part of parts) {
-      part = part.replace(/~1/g, "/").replace(/~0/g, "~");
-      if (current.hasOwnProperty(part)) {
-        current = current[part];
-      } else {
-        // No matching definition found, that's an error (bogus schema?)
-        throw new Error(`Could not find a definition for ${$ref}.`);
-      }
-    }
-    return current;
+
+  if (!match || match.length === 0) {
+    // No matching definition found, that's an error (bogus schema?)
+    throw new Error(`Could not find a definition for ${$ref}.`);
   }
 
-  // No matching definition found, that's an error (bogus schema?)
-  throw new Error(`Could not find a definition for ${$ref}.`);
+  const parts = match[1].split("/");
+  let current = definitions;
+  for (let part of parts) {
+    part = part.replace(/~1/g, "/").replace(/~0/g, "~");
+    if (current.hasOwnProperty(part)) {
+      current = current[part];
+    } else {
+      // No matching definition found, that's an error (bogus schema?)
+      throw new Error(`Could not find a definition for ${$ref}.`);
+    }
+  }
+  return current;
 }
 
 // In the case where we have to implicitly create a schema, it is useful to know what type to use
@@ -468,7 +469,7 @@ export function resolveSchema(schema, definitions = {}, formData = {}) {
 
 function resolveReference(schema, definitions, formData) {
   // Retrieve the referenced schema definition.
-  const $refSchema = findSchemaDefinition(schema.$ref, definitions);
+    const $refSchema = findSchemaDefinition(schema.$ref, definitions);
   // Drop the $ref property of the source schema.
   const { $ref, ...localSchema } = schema;
   // Update referenced schema definition with local schema properties.

--- a/src/utils.js
+++ b/src/utils.js
@@ -457,7 +457,7 @@ export function stubExistingAdditionalProperties(
 export function resolveSchema(schema, definitions = {}, formData = {}) {
   if (schema.hasOwnProperty("$ref")) {
     return resolveReference(schema, definitions, formData);
-  } else if (schema.hasOwnProperty("dependencies")) {
+  } else if (schema.hasOwnProperty("dependentSchemas") || schema.hasOwnProperty("dependencies")) {
     const resolvedSchema = resolveDependencies(schema, definitions, formData);
     return retrieveSchema(resolvedSchema, definitions, formData);
   } else {
@@ -496,7 +496,14 @@ export function retrieveSchema(schema, definitions = {}, formData = {}) {
 
 function resolveDependencies(schema, definitions, formData) {
   // Drop the dependencies from the source schema.
-  let { dependencies = {}, ...resolvedSchema } = schema;
+  let { dependentSchemas, ...resolvedSchema } = schema;
+
+  // dependencies is the legacy field.
+  // according to the spec http://json-schema.org/draft/2019-09/release-notes.html:
+  // > dependencies has been split into dependentSchemas and dependentRequired
+  // TODO: support dependentRequired
+  let dependencies = dependentSchemas ? dependentSchemas : schema.dependencies;
+
   // Process dependencies updating the local schema properties as appropriate.
   for (const dependencyKey in dependencies) {
     // Skip this dependency if its trigger property is not present.


### PR DESCRIPTION
Update field names according to the latest spec 2019-09:

> The old syntax for these keywords is not an error (and the default meta-schema still validates them), so implementations can therefore offer a compatibility mode. However, migrating to the new keywords is straightforward and should be preferred.

- definitions is now $defs
- dependencies has been split into dependentSchemas and dependentRequired